### PR TITLE
Crear elemento link en las combinaciones

### DIFF
--- a/mapametro.js
+++ b/mapametro.js
@@ -154,6 +154,9 @@ function initCombinaciones() {
 }
 
 function renderCombinacion(estacionDOM, lineaComb, abierta) {
+	linkLineaDOM = document.createElement("a")
+	linkLineaDOM.href = "#"+lineaComb
+	linkLineaDOM.appendChild(estacionDOM)
 	estacionDOM.classList.add("combinacion")
 	estacionDOM.classList.add(lineaComb)
 	const marcadorDOM = estacionDOM.getElementsByClassName("marcador")[0]

--- a/mapametro.js
+++ b/mapametro.js
@@ -154,12 +154,10 @@ function initCombinaciones() {
 }
 
 function renderCombinacion(estacionDOM, lineaComb, abierta) {
-	linkLineaDOM = document.createElement("a")
-	linkLineaDOM.href = "#"+lineaComb
-	linkLineaDOM.appendChild(estacionDOM)
 	estacionDOM.classList.add("combinacion")
 	estacionDOM.classList.add(lineaComb)
 	const marcadorDOM = estacionDOM.getElementsByClassName("marcador")[0]
+	makeLinkTo(marcadorDOM, "#"+lineaComb)
 	const bordeDOM = estacionDOM.getElementsByClassName("borde")[0]
 	const rellenoDOM = estacionDOM.getElementsByClassName("relleno")[0]
 	const estX = parseInt(bordeDOM.getAttribute("cx"))
@@ -181,6 +179,13 @@ function renderCombinacion(estacionDOM, lineaComb, abierta) {
 	}
 	marcadorDOM.appendChild(combCircleDOM)
 	marcadorDOM.appendChild(combLabelDOM)
+}
+
+function makeLinkTo(element, dest) {
+	var link = document.createElementNS("http://www.w3.org/2000/svg", "a")
+	element.parentNode.insertBefore(link, element)
+	link.appendChild(element)
+	link.setAttribute("href", dest)
 }
 
 function initExtras() {


### PR DESCRIPTION
Para que cuando uno haga clic en el Baquedano de la L1, el navegador se vaya directo a la L5.
No sé como hostear esto localmente sin el data.js así que no he probado si el pull request funciona. Es posible que me eche todo.